### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,28 @@ body {
   background-color: #f5f5f5;
   color: #4e4e4e;
    
+   }
+
+body.dark-mode {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+body.dark-mode a {
+  color: #f5f5f5;
+}
+
+body.dark-mode a:hover {
+  color: #66b2ff;
+}
+
+body.dark-mode .navbar {
+  background-color: #222 !important;
+}
+
+body.dark-mode .nav-link,
+body.dark-mode .navbar-brand {
+  color: #f5f5f5 !important;
 }
 
 h1,
@@ -1307,7 +1329,7 @@ font-family: "Monaco";
 }
 
 
- .note1{
+  .note1{
 
 
 
@@ -1317,4 +1339,4 @@ font-family: "Monaco";
   
     display:inline;
 
- }
+   }

--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
           <li class="nav-item">
             <a class="nav-link js-scroll" href="#contact">Contact</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#" id="darkModeToggle">Dark Mode</a>
+          </li>
         </ul>
       </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,17 @@
 (function ($) {
 	"use strict";
-	var nav = $('nav');
+        var nav = $('nav');
   var navHeight = nav.outerHeight();
+
+  if (localStorage.getItem('dark-mode') === 'true') {
+    $('body').addClass('dark-mode');
+  }
+
+  $('#darkModeToggle').on('click', function (e) {
+    e.preventDefault();
+    $('body').toggleClass('dark-mode');
+    localStorage.setItem('dark-mode', $('body').hasClass('dark-mode'));
+  });
   
   $('.navbar-toggler').on('click', function() {
     if( ! $('#mainNav').hasClass('navbar-reduce')) {


### PR DESCRIPTION
## Summary
- add dark mode toggle to navigation
- implement dark mode styles and persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be9481c1048322a84bb1e9fa5ed0dc